### PR TITLE
fix: activate `all` feature of `socket2` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 crossbeam-channel = "0.5"
 futures = "0.3"
 
-socket2 = "0.5"
+socket2 = { version = "0.5", features = ["all"] }
 mio = { version = "1", features = ["os-poll", "net"] }
 tokio = { version = "1" }
 


### PR DESCRIPTION
`nio` v0.0.1 fails to compile:

```txt
cargo check
    Updating crates.io index
   Compiling proc-macro2 v1.0.89
   Compiling unicode-ident v1.0.13
   Compiling autocfg v1.4.0
   Compiling libc v0.2.162
    Checking pin-project-lite v0.2.15
    Checking futures-core v0.3.31
    Checking futures-sink v0.3.31
    Checking futures-io v0.3.31
    Checking pin-utils v0.1.0
    Checking futures-task v0.3.31
    Checking memchr v2.7.4
   Compiling crossbeam-utils v0.8.20
   Compiling quote2-macros v0.9.0
    Checking log v0.4.22
    Checking mpmc-channel v0.0.0 (/home/kanarus/projects/kanarus/nio/libs/mpmc-channel)
warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:46:20
   |
46 |     pub fn produce(&self) -> Producer<T> {
   |                    ^^^^^     ----------- the lifetime gets resolved as `'_`
   |                    |
   |                    this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
46 |     pub fn produce(&self) -> Producer<'_, T> {
   |                                       +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:55:20
   |
55 |     pub fn consume(&self) -> Consume<T> {
   |                    ^^^^^     ---------- the lifetime gets resolved as `'_`
   |                    |
   |                    this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
55 |     pub fn consume(&self) -> Consume<'_, T> {
   |                                      +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:63:24
   |
63 |     pub fn try_produce(&self) -> Result<Producer<T>, WouldBlock> {
   |                        ^^^^^            ----------- the lifetime gets resolved as `'_`
   |                        |
   |                        this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
63 |     pub fn try_produce(&self) -> Result<Producer<'_, T>, WouldBlock> {
   |                                                  +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:75:24
   |
75 |     pub fn try_consume(&self) -> Result<Consume<T>, WouldBlock> {
   |                        ^^^^^            ---------- the lifetime gets resolved as `'_`
   |                        |
   |                        this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
75 |     pub fn try_consume(&self) -> Result<Consume<'_, T>, WouldBlock> {
   |                                                 +++

warning: `mpmc-channel` (lib) generated 4 warnings
   Compiling slab v0.4.9
    Checking tokio v1.41.1
    Checking futures-channel v0.3.31
    Checking crossbeam-channel v0.5.13
   Compiling quote v1.0.37
    Checking mio v1.0.2
    Checking socket2 v0.5.7
   Compiling syn v2.0.87
   Compiling quote2 v0.9.0
   Compiling futures-macro v0.3.31
   Compiling nio-macros v0.1.0 (/home/kanarus/projects/kanarus/nio/macros)
    Checking futures-util v0.3.31
    Checking futures-executor v0.3.31
    Checking futures v0.3.31
    Checking nio v0.0.1 (/home/kanarus/projects/kanarus/nio)
error[E0599]: no method named `nonblocking` found for struct `Type` in the current scope
   --> src/net/tcp/socket.rs:165:21
    |
165 |         let ty = ty.nonblocking();
    |                     ^^^^^^^^^^^ method not found in `Type`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `nio` (lib) due to 1 previous error
```

Then, we see following `cfg` for `nonblocking()` in `socket2` crate:

- https://github.com/rust-lang/socket2/blob/f0836965a165f357ea3be6f5cc47544130d1bfde/src/sys/unix.rs#L415-L433
```rust
impl Type {
    /// Set `SOCK_NONBLOCK` on the `Type`.
    #[cfg(all(
        feature = "all",
        any(
            target_os = "android",
            target_os = "dragonfly",
            target_os = "freebsd",
            target_os = "fuchsia",
            target_os = "illumos",
            target_os = "linux",
            target_os = "netbsd",
            target_os = "openbsd",
            target_os = "cygwin",
        )
    ))]
    pub const fn nonblocking(self) -> Type {
        Type(self.0 | libc::SOCK_NONBLOCK)
    }
```

and this `"all"` feature is not activated by default:

- https://github.com/rust-lang/socket2/blob/f0836965a165f357ea3be6f5cc47544130d1bfde/Cargo.toml#L65-L68
```toml
[features]
# Enable all API, even ones not available on all OSs.
all = []

```

So this PR adds `features = ["all"]` in `nio`'s `[dependencies]` and then it successfully compiles.