### PR TITLE
refactor: fix `warning: lifetime flowing from input to output with different syntax can be confusing`

### DIFF
--- a/libs/mpmc-channel/src/lib.rs
+++ b/libs/mpmc-channel/src/lib.rs
@@ -43,7 +43,7 @@ impl<T> MPMC<T> {
     }
 
     #[inline]
-    pub fn produce(&self) -> Producer<T> {
+    pub fn produce(&self) -> Producer<'_, T> {
         let guard = self.inner.lock().unwrap();
         Producer {
             cvar: &self.cvar,
@@ -52,7 +52,7 @@ impl<T> MPMC<T> {
     }
 
     #[inline]
-    pub fn consume(&self) -> Consume<T> {
+    pub fn consume(&self) -> Consume<'_, T> {
         let guard = self.inner.lock().unwrap();
         Consume {
             cvar: &self.cvar,
@@ -60,7 +60,7 @@ impl<T> MPMC<T> {
         }
     }
 
-    pub fn try_produce(&self) -> Result<Producer<T>, WouldBlock> {
+    pub fn try_produce(&self) -> Result<Producer<'_, T>, WouldBlock> {
         let guard = match self.inner.try_lock() {
             Ok(val) => val,
             Err(TryLockError::WouldBlock) => return Err(WouldBlock),
@@ -72,7 +72,7 @@ impl<T> MPMC<T> {
         })
     }
 
-    pub fn try_consume(&self) -> Result<Consume<T>, WouldBlock> {
+    pub fn try_consume(&self) -> Result<Consume<'_, T>, WouldBlock> {
         let guard = match self.inner.try_lock() {
             Ok(val) => val,
             Err(TryLockError::WouldBlock) => return Err(WouldBlock),

--- a/src/net/tcp/split.rs
+++ b/src/net/tcp/split.rs
@@ -21,7 +21,7 @@ pub struct WriteHalf<'a> {
     me: &'a TcpStream,
 }
 
-pub fn split(stream: &mut TcpStream) -> (ReadHalf, WriteHalf) {
+pub fn split(stream: &mut TcpStream) -> (ReadHalf<'_>, WriteHalf<'_>) {
     (ReadHalf { me: stream }, WriteHalf { me: stream })
 }
 

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -135,7 +135,7 @@ impl TcpStream {
         self.io.set_ttl(ttl)
     }
 
-    pub fn split(&mut self) -> (ReadHalf, WriteHalf) {
+    pub fn split(&mut self) -> (ReadHalf<'_>, WriteHalf<'_>) {
         split(self)
     }
 

--- a/src/runtime/handle.rs
+++ b/src/runtime/handle.rs
@@ -55,7 +55,7 @@ impl Handle {
         crate::future::block_on(fut)
     }
 
-    pub fn enter(&self) -> EnterGuard {
+    pub fn enter(&self) -> EnterGuard<'_> {
         self.ctx.clone().init();
         EnterGuard::new()
     }

--- a/src/runtime/multithread/mod.rs
+++ b/src/runtime/multithread/mod.rs
@@ -70,7 +70,7 @@ impl Runtime {
         &self.handle
     }
 
-    pub fn enter(&self) -> EnterGuard {
+    pub fn enter(&self) -> EnterGuard<'_> {
         self.handle.ctx.clone().init();
         EnterGuard::new()
     }


### PR DESCRIPTION
Fixing warnings generated by current `nio` v0.0.1:

```txt
cargo check
warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:46:20
   |
46 |     pub fn produce(&self) -> Producer<T> {
   |                    ^^^^^     ----------- the lifetime gets resolved as `'_`
   |                    |
   |                    this lifetime flows to the output
   |
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
46 |     pub fn produce(&self) -> Producer<'_, T> {
   |                                       +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:55:20
   |
55 |     pub fn consume(&self) -> Consume<T> {
   |                    ^^^^^     ---------- the lifetime gets resolved as `'_`
   |                    |
   |                    this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
55 |     pub fn consume(&self) -> Consume<'_, T> {
   |                                      +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:63:24
   |
63 |     pub fn try_produce(&self) -> Result<Producer<T>, WouldBlock> {
   |                        ^^^^^            ----------- the lifetime gets resolved as `'_`
   |                        |
   |                        this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
63 |     pub fn try_produce(&self) -> Result<Producer<'_, T>, WouldBlock> {
   |                                                  +++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> libs/mpmc-channel/src/lib.rs:75:24
   |
75 |     pub fn try_consume(&self) -> Result<Consume<T>, WouldBlock> {
   |                        ^^^^^            ---------- the lifetime gets resolved as `'_`
   |                        |
   |                        this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
75 |     pub fn try_consume(&self) -> Result<Consume<'_, T>, WouldBlock> {
   |                                                 +++

warning: `mpmc-channel` (lib) generated 4 warnings
warning: lifetime flowing from input to output with different syntax can be confusing
   --> src/net/tcp/stream.rs:138:18
    |
138 |     pub fn split(&mut self) -> (ReadHalf, WriteHalf) {
    |                  ^^^^^^^^^      --------  --------- the lifetimes get resolved as `'_`
    |                  |              |
    |                  |              the lifetimes get resolved as `'_`
    |                  this lifetime flows to the output
    |
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
    |
138 |     pub fn split(&mut self) -> (ReadHalf<'_>, WriteHalf<'_>) {
    |                                         ++++           ++++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/net/tcp/split.rs:24:22
   |
24 | pub fn split(stream: &mut TcpStream) -> (ReadHalf, WriteHalf) {
   |                      ^^^^^^^^^^^^^^      --------  --------- the lifetimes get resolved as `'_`
   |                      |                   |
   |                      |                   the lifetimes get resolved as `'_`
   |                      this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
24 | pub fn split(stream: &mut TcpStream) -> (ReadHalf<'_>, WriteHalf<'_>) {
   |                                                  ++++           ++++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/runtime/handle.rs:58:18
   |
58 |     pub fn enter(&self) -> EnterGuard {
   |                  ^^^^^     ---------- the lifetime gets resolved as `'_`
   |                  |
   |                  this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
58 |     pub fn enter(&self) -> EnterGuard<'_> {
   |                                      ++++

warning: lifetime flowing from input to output with different syntax can be confusing
  --> src/runtime/multithread/mod.rs:73:18
   |
73 |     pub fn enter(&self) -> EnterGuard {
   |                  ^^^^^     ---------- the lifetime gets resolved as `'_`
   |                  |
   |                  this lifetime flows to the output
   |
help: one option is to remove the lifetime for references and use the anonymous lifetime for paths
   |
73 |     pub fn enter(&self) -> EnterGuard<'_> {
   |                                      ++++

warning: `nio` (lib) generated 4 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
```